### PR TITLE
Add support for RTL-SDR serial numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ radio:
   samplerate: 1000000
   gain: 49
   # ppm_correction: 0
+  serial_number: 00000001
 
 # All satellites you want to track
 satellites:

--- a/config.yml
+++ b/config.yml
@@ -29,6 +29,7 @@ radio:
   samplerate: 2400000
   gain: 49
   # ppm_correction: 0
+  serial_number: 00000001
 
 # All satellites you want to track
 satellites:

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -16,6 +16,7 @@ struct RadioConfig
     std::vector<long> frequencies;
     long samplerate;
     int gain;
+    std::string serial_number;
 
     // PPM Correction
     bool ppm_enabled;

--- a/src/config/yaml_cpp_converts.h
+++ b/src/config/yaml_cpp_converts.h
@@ -43,6 +43,8 @@ namespace YAML
             node["frequencies"] = (std::vector<long>)sdrConfig.frequencies;
             node["samplerate"] = (long)sdrConfig.samplerate;
             node["gain"] = (int)sdrConfig.gain;
+            if (!sdrConfig.serial_number.empty())
+                node["serial_number"] = (std::string)sdrConfig.serial_number;
             if (sdrConfig.ppm_enabled)
                 node["ppm_correction"] = (double)sdrConfig.ppm;
             return node;
@@ -58,6 +60,12 @@ namespace YAML
             sdrConfig.frequencies = node["frequencies"].as<std::vector<long>>();
             sdrConfig.samplerate = node["samplerate"].as<long>();
             sdrConfig.gain = node["gain"].as<int>();
+            if (node["serial_number"].IsDefined())
+            {
+                sdrConfig.serial_number = node["serial_number"].as<std::string>();
+            }
+            else
+                sdrConfig.serial_number = "";
 
             if (node["ppm_correction"].IsDefined())
             {

--- a/src/dsp/dsp.h
+++ b/src/dsp/dsp.h
@@ -15,6 +15,7 @@ private:
     int d_samplerate;
     int d_frequency;
     int d_gain;
+    std::string d_serial_number;
 
     rtlsdr_dev *rtlsdr_device;
     std::mutex rtlsdr_mutex;
@@ -32,7 +33,7 @@ private:
     static void _rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx);
 
 public:
-    DeviceDSP(int samplerate, int frequency, int gain);
+    DeviceDSP(int samplerate, int frequency, int gain, std::string serial);
     ~DeviceDSP();
 
     void start();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,8 @@ int main(int argc, char *argv[])
     // Start SDR
     std::shared_ptr<DeviceDSP> device_dsp = std::make_shared<DeviceDSP>(configManager->getConfig().radio_config.samplerate,
                                                                         configManager->getConfig().radio_config.frequencies[0],
-                                                                        configManager->getConfig().radio_config.gain);
+                                                                        configManager->getConfig().radio_config.gain,
+                                                                        configManager->getConfig().radio_config.serial_number);
     device_dsp->start();
 
     // Start scheduler


### PR DESCRIPTION
Added support for RTL-SDR serial number in the YAML config.
Hopefully my bad code isn't too bad. I'm not a fan of the switch and if statements in dsb.cpp but it does work.
I thought rtlsdr_get_index_by_serial() would return -1 because of the empty string but the docs means a NULL pointer. I guess I should set the index to 0 with the if instead of the switch.